### PR TITLE
Backport: frame guards to 'ci-proof'

### DIFF
--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -3,8 +3,10 @@ use linux_gateway::{guard_header, FrameError};
 fn mk_hdr(ver: u8, typ: u8, len: u16) -> [u8; 10] {
     let sync = 0xA55Au16.to_le_bytes();
     let lenb = len.to_le_bytes();
-    let crc  = (0u32).to_le_bytes();
-    [sync[0], sync[1], ver, typ, lenb[0], lenb[1], crc[0], crc[1], crc[2], crc[3]]
+    let crc = (0u32).to_le_bytes();
+    [
+        sync[0], sync[1], ver, typ, lenb[0], lenb[1], crc[0], crc[1], crc[2], crc[3],
+    ]
 }
 
 #[test]

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -1,0 +1,26 @@
+use linux_gateway::{guard_header, FrameError};
+
+fn mk_hdr(ver: u8, typ: u8, len: u16) -> [u8; 10] {
+    let sync = 0xA55Au16.to_le_bytes();
+    let lenb = len.to_le_bytes();
+    let crc  = (0u32).to_le_bytes();
+    [sync[0], sync[1], ver, typ, lenb[0], lenb[1], crc[0], crc[1], crc[2], crc[3]]
+}
+
+#[test]
+fn rejects_unknown_version() {
+    let hdr = mk_hdr(0x7F, 0x01, 0);
+    match guard_header(&hdr) {
+        Err(FrameError::UnknownVersion(0x7F)) => {}
+        other => panic!("expected UnknownVersion(0x7F), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unknown_type() {
+    let hdr = mk_hdr(0x01, 0xFF, 0);
+    match guard_header(&hdr) {
+        Err(FrameError::UnknownType(0xFF)) => {}
+        other => panic!("expected UnknownType(0xFF), got {other:?}"),
+    }
+}


### PR DESCRIPTION
Reject unknown version/type via guard_header(); adds compat tests.