### PR TITLE
Cutover: frame guards + decode mapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,13 @@ pub mod proto {
 
 #[derive(Debug, Error)]
 pub enum FrameError {
-    #[error("decode failed")] Decode,
+    #[error("decode failed")]
+    Decode,
 
-    #[error("unknown version {0:#04x}")] UnknownVersion(u8),
-    #[error("unknown type {0:#04x}")] UnknownType(u8),
+    #[error("unknown version {0:#04x}")]
+    UnknownVersion(u8),
+    #[error("unknown type {0:#04x}")]
+    UnknownType(u8),
 
     #[error("short header")]
     ShortHeader,
@@ -70,9 +73,13 @@ pub fn decode_calc_response(
     // backport-guards: response
     if frame.len() >= 4 {
         let ver = frame[2];
-        if ver != 1 { return Err(FrameError::UnknownVersion(ver)); }
+        if ver != 1 {
+            return Err(FrameError::UnknownVersion(ver));
+        }
         let typ = frame[3];
-        if typ != 1 && typ != 2 { return Err(FrameError::UnknownType(typ)); }
+        if typ != 1 && typ != 2 {
+            return Err(FrameError::UnknownType(typ));
+        }
     }
 
     if frame.len() < 10 {
@@ -174,9 +181,13 @@ pub fn decode_calc_request(
     // backport-guards: request
     if frame.len() >= 4 {
         let ver = frame[2];
-        if ver != 1 { return Err(FrameError::UnknownVersion(ver)); }
+        if ver != 1 {
+            return Err(FrameError::UnknownVersion(ver));
+        }
         let typ = frame[3];
-        if typ != 1 && typ != 2 { return Err(FrameError::UnknownType(typ)); }
+        if typ != 1 && typ != 2 {
+            return Err(FrameError::UnknownType(typ));
+        }
     }
 
     if frame.len() < 10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@ pub mod proto {
 
 #[derive(Debug, Error)]
 pub enum FrameError {
+    #[error("decode failed")] Decode,
+
+    #[error("unknown version {0:#04x}")] UnknownVersion(u8),
+    #[error("unknown type {0:#04x}")] UnknownType(u8),
+
     #[error("short header")]
     ShortHeader,
     #[error("bad sync")]
@@ -62,6 +67,14 @@ pub fn encode_calc_request(a: u32, b: u32) -> Vec<u8> {
 pub fn decode_calc_response(
     frame: &[u8],
 ) -> Result<proto::rpmsg::calc::v1::CalcResponse, FrameError> {
+    // backport-guards: response
+    if frame.len() >= 4 {
+        let ver = frame[2];
+        if ver != 1 { return Err(FrameError::UnknownVersion(ver)); }
+        let typ = frame[3];
+        if typ != 1 && typ != 2 { return Err(FrameError::UnknownType(typ)); }
+    }
+
     if frame.len() < 10 {
         return Err(FrameError::ShortHeader);
     }
@@ -87,7 +100,7 @@ pub fn decode_calc_response(
         return Err(FrameError::Length);
     }
 
-    Ok(proto::rpmsg::calc::v1::CalcResponse::decode(payload)?)
+    proto::rpmsg::calc::v1::CalcResponse::decode(payload).map_err(|_| FrameError::Decode)
 }
 
 pub fn encode_calc_response(sum: u32) -> Vec<u8> {
@@ -158,6 +171,14 @@ pub fn encode_calc_request_with_trace(a: u32, b: u32) -> (Vec<u8>, Vec<u8>, u64)
 pub fn decode_calc_request(
     frame: &[u8],
 ) -> Result<proto::rpmsg::calc::v1::CalcRequest, FrameError> {
+    // backport-guards: request
+    if frame.len() >= 4 {
+        let ver = frame[2];
+        if ver != 1 { return Err(FrameError::UnknownVersion(ver)); }
+        let typ = frame[3];
+        if typ != 1 && typ != 2 { return Err(FrameError::UnknownType(typ)); }
+    }
+
     if frame.len() < 10 {
         return Err(FrameError::ShortHeader);
     }
@@ -183,5 +204,5 @@ pub fn decode_calc_request(
         return Err(FrameError::Length);
     }
 
-    Ok(proto::rpmsg::calc::v1::CalcRequest::decode(payload)?)
+    proto::rpmsg::calc::v1::CalcRequest::decode(payload).map_err(|_| FrameError::Decode)
 }

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -1,0 +1,27 @@
+use linux_gateway::{decode_calc_request, decode_calc_response, FrameError};
+
+#[test]
+fn rejects_unknown_version_resp() {
+    let sync = 0xA55Au16.to_le_bytes();
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&sync);
+    frame.push(0x7F); // ver (unknown)
+    frame.push(1);    // type = CalcResp
+    match decode_calc_response(&frame) {
+        Err(FrameError::UnknownVersion(0x7F)) => {}
+        other => panic!("expected UnknownVersion(0x7F), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unknown_type_req() {
+    let sync = 0xA55Au16.to_le_bytes();
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&sync);
+    frame.push(1);    // ver = 1
+    frame.push(0xFF); // type unknown
+    match decode_calc_request(&frame) {
+        Err(FrameError::UnknownType(0xFF)) => {}
+        other => panic!("expected UnknownType(0xFF), got {other:?}"),
+    }
+}


### PR DESCRIPTION
Restore lib.rs from #27 (UnknownVersion/UnknownType/Decode, header guards, prost decode mapping).